### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-linux.yml
+++ b/.github/workflows/dotnet-linux.yml
@@ -1,5 +1,8 @@
 name: .NET Linux Build & Test
 
+permissions:
+  contents: read
+
 env:
   # Replace with your solution name, i.e. MyWpfApp.sln.
   SOLUTION_NAME: "./ConsoleProgressBar/ConsoleProgressBar.sln"


### PR DESCRIPTION
Potential fix for [https://github.com/3rikF/ConsoleProgress/security/code-scanning/5](https://github.com/3rikF/ConsoleProgress/security/code-scanning/5)

Add an explicit top-level `permissions` block in `.github/workflows/dotnet-linux.yml` so all jobs inherit least-privilege token access.

Best single fix without changing functionality:
- Insert at workflow root (after `name:` and before `env:`):
  - `permissions:`
  - `contents: read`

This is sufficient for current steps (`checkout`, build/test, artifact upload, NuGet push via external API key) and satisfies CodeQL’s minimal recommendation. No imports/dependencies/method changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
